### PR TITLE
Update: Add helper functions

### DIFF
--- a/src/lib/fs.go
+++ b/src/lib/fs.go
@@ -1,0 +1,25 @@
+package lib
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+const pkgName = "lib"
+
+// errInvalidPath indicates that the root path was invalid
+var errInvalidPath = fmt.Errorf("(%s): invalid path", pkgName)
+
+/*
+IsInvalidPathErr indicates if an error was returned because of invalid input path
+*/
+func IsInvalidPathErr(err error) bool {
+	return errors.Is(err, errInvalidPath)
+}
+
+func PathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/src/lib/fs.go
+++ b/src/lib/fs.go
@@ -2,7 +2,9 @@ package lib
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 )
@@ -11,6 +13,8 @@ const pkgName = "lib"
 
 // errInvalidPath indicates that the root path was invalid
 var errInvalidPath = fmt.Errorf("(%s): invalid path", pkgName)
+
+var filepathWalk = filepath.Walk
 
 /*
 IsInvalidPathErr indicates if an error was returned because of invalid input path
@@ -22,4 +26,27 @@ func IsInvalidPathErr(err error) bool {
 func PathExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+/*
+WalkPath walks through the root directory, running the input `walkFunc` function on all
+files. If the root path is invalid, a custom error is returned, use IsInvalidPathErr
+to check for this.
+
+Note: The parameter `walkFunc` will be selectively run on files
+*/
+func WalkPath(path string, walkFunc filepath.WalkFunc) error {
+	if !PathExists(path) {
+		return errInvalidPath
+	}
+
+	err := filepathWalk(path, func(path string, info fs.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+
+		return walkFunc(path, info, err)
+	})
+
+	return errors.Wrapf(err, "(%s/WalkPath)", pkgName)
 }

--- a/src/lib/fs_test.go
+++ b/src/lib/fs_test.go
@@ -1,0 +1,41 @@
+package lib
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInvalidPathErr(t *testing.T) {
+	for _, err := range []error{
+		fmt.Errorf("(%s): invalid path", pkgName),
+		errors.New("(TestIsInvalidPathErr): test error"),
+		nil,
+		fmt.Errorf("(%s/TestIsInvalidPathErr): test error", pkgName),
+		errInvalidPath,
+	} {
+		switch errors.Is(err, errInvalidPath) {
+		case true:
+			assert.True(t, IsInvalidPathErr(err))
+
+		case false:
+			assert.False(t, IsInvalidPathErr(err))
+		}
+	}
+}
+
+func TestPathExists(t *testing.T) {
+	for _, path := range []string{
+		".",
+		"/root",
+		"/user",
+		"invalid path",
+	} {
+		_, err := os.Stat(path)
+
+		assert.Equal(t, err == nil, PathExists(path))
+	}
+}

--- a/src/lib/fs_test.go
+++ b/src/lib/fs_test.go
@@ -2,12 +2,18 @@ package lib
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
+
+func reset() {
+	filepathWalk = filepath.Walk
+}
 
 func TestIsInvalidPathErr(t *testing.T) {
 	for _, err := range []error{
@@ -38,4 +44,55 @@ func TestPathExists(t *testing.T) {
 
 		assert.Equal(t, err == nil, PathExists(path))
 	}
+}
+
+func TestWalkPath_PathError(t *testing.T) {
+	reset()
+
+	filepathWalk = func(_ string, _ filepath.WalkFunc) error {
+		return nil
+	}
+
+	walkFunc := filepath.WalkFunc(nil)
+	for _, path := range []string{
+		".",
+		"../..",
+		"<invalid path>",
+		"/root",
+	} {
+		if PathExists(path) {
+			assert.NoError(t, WalkPath(path, walkFunc))
+		} else {
+			err := WalkPath(path, walkFunc)
+
+			assert.Error(t, err)
+			assert.True(t, IsInvalidPathErr(err))
+		}
+	}
+}
+
+func TestWalkPath_WalkError(t *testing.T) {
+	reset()
+
+	// Failure when walking the path should return an error
+	filepathWalk = func(_ string, _ filepath.WalkFunc) error {
+		return fmt.Errorf("(%s/TestWalk_Error): test error", pkgName)
+	}
+
+	assert.Error(t, WalkPath(".", nil))
+}
+
+func TestWalkPath(t *testing.T) {
+	reset()
+
+	walkFunc := func(path string, info fs.FileInfo, err error) error {
+		// `walkFunc` should be run on non-empty path, without any errors, and
+		// specifically on files - i.e. no directories
+		assert.NotEmptyf(t, path, `walkFunc run on empty path: "%s"`, path)
+		assert.NoErrorf(t, err, `walkFunc run on path with error: "%s"`, path)
+		assert.Falsef(t, info.IsDir(), `walkFunc run on directory: "%s"`, path)
+		return nil
+	}
+
+	assert.NoError(t, WalkPath("../..", walkFunc))
 }

--- a/src/lib/fs_test.go
+++ b/src/lib/fs_test.go
@@ -16,20 +16,14 @@ func reset() {
 }
 
 func TestIsInvalidPathErr(t *testing.T) {
-	for _, err := range []error{
-		fmt.Errorf("(%s): invalid path", pkgName),
-		errors.New("(TestIsInvalidPathErr): test error"),
-		nil,
-		fmt.Errorf("(%s/TestIsInvalidPathErr): test error", pkgName),
-		errInvalidPath,
+	for err, expected := range map[error]bool{
+		fmt.Errorf("(%s): invalid path", pkgName):        false,
+		errors.New("(TestIsInvalidPathErr): test error"): false,
+		nil: false,
+		fmt.Errorf("(%s/TestIsInvalidPathErr): test error", pkgName): false,
+		errInvalidPath: true,
 	} {
-		switch errors.Is(err, errInvalidPath) {
-		case true:
-			assert.True(t, IsInvalidPathErr(err))
-
-		case false:
-			assert.False(t, IsInvalidPathErr(err))
-		}
+		assert.Equal(t, expected, IsInvalidPathErr(err))
 	}
 }
 
@@ -41,7 +35,6 @@ func TestPathExists(t *testing.T) {
 		"invalid path",
 	} {
 		_, err := os.Stat(path)
-
 		assert.Equal(t, err == nil, PathExists(path))
 	}
 }


### PR DESCRIPTION
This PR introduces a new package - `src/lib` the package will act as a library, primarily as a container for helper functions that will be consumed by other parts of the codebase

The helper functions currently in the package include:

 - `lib.PathExists`: Ensures a path is valid. Returns a boolean indicating the same.
 - `lib.WalkPath`: Iterates over all files under a path. Takes a custom function as the input, this function is executed over each file iteratively. Returns an error

The package introduces a (private) sentinel error - `errInvalidPath`. The error indicates an invalid path, currently, the error is being returned by a check within `lib.WalkPath`.

To check if the error being returned is `errInvalidPath`, the package `lib` exposes a public function

```go
func IsInvalidPathErr(err error) bool
```

As the name indicates, the function returns a boolean indicating if an error is `errInvalidPath` or not

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [x] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [ ] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [x] I've read the [`Code of Conduct`](../blob/master/CODE_OF_CONDUCT.md) and this pull request adheres to it.
- [x] I've read the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) guide.
- [x] I've run the complete test-suite using `make test-suite`, and it passed with no errors.
- [x] I've written new tests for all changes introduced in this pull request (where applicable).
- [x] I've documented any new methods/structures/packages added.

<!--
    Leave this section as-is, no changes are to be made below this point!
-->
## Review Process

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches.
3. For shorter, "quick" PRs, use your best judgment on the previous point.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.
6. In case of a potential bug in PR, be sure to add steps to reproduce the issue (where applicable)
